### PR TITLE
Add Wei Name Service (WNS) support for .wei domains

### DIFF
--- a/.changeset/wei-domains.md
+++ b/.changeset/wei-domains.md
@@ -1,0 +1,9 @@
+---
+"@1001-digital/ethereum-names": minor
+---
+
+Add support for the Wei Name Service (WNS) — resolve, reverse-resolve, and read records for `.wei` names, powered by [`wns-utils`](https://www.npmjs.com/package/wns-utils).
+
+- `.wei` names now route to the new `wns` system (`detectSystem`/`system` return `'wns'`).
+- `reverseAll` returns `{ ens, gns, wns }`, and `reversePriority` defaults to `['ens', 'gns', 'wns']`.
+- New `wnsContract` config option and exported `DEFAULT_WNS_CONTRACT` constant.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # @1001-digital/ethereum-names
 
-One clean, [viem](https://viem.sh)-powered API to resolve Ethereum names across both
-[ENS](https://ens.domains) and the [Gwei Name Service](https://gwei.domains) (GNS).
+One clean, [viem](https://viem.sh)-powered API to resolve Ethereum names across
+[ENS](https://ens.domains), the [Gwei Name Service](https://gwei.domains) (GNS), and the
+[Wei Name Service](https://wei.domains) (WNS).
 
-Point it at a name — `vitalik.eth` or `alice.gwei` — and it figures out which system to
-ask. Point it at an address and it gives you back the primary name. No branching in your
-app code.
+Point it at a name — `vitalik.eth`, `alice.gwei`, or `alice.wei` — and it figures out which
+system to ask. Point it at an address and it gives you back the primary name. No branching
+in your app code.
 
 ## Install
 
@@ -25,27 +26,29 @@ const names = createEthereumNames()
 // Forward: name → address (the system is detected from the name)
 await names.resolve('vitalik.eth')    // ENS → '0xd8dA...' | null
 await names.resolve('alice.gwei')     // GNS → '0x...'    | null
+await names.resolve('alice.wei')      // WNS → '0x...'    | null
 await names.resolve('alice')          // bare label → treated as alice.gwei
 await names.resolve('0xd8dA...')      // address → returned checksummed
 
-// Reverse: address → primary name (tries ENS, then GNS)
+// Reverse: address → primary name (tries ENS, then GNS, then WNS)
 await names.reverse('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
-// => 'vitalik.eth' | 'alice.gwei' | null
+// => 'vitalik.eth' | 'alice.gwei' | 'alice.wei' | null
 
-// Reverse across BOTH systems at once (when an address has names in each)
+// Reverse across ALL systems at once (when an address has names in each)
 await names.reverseAll('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
-// => { ens: 'vitalik.eth', gns: 'vitalik.gwei' }
+// => { ens: 'vitalik.eth', gns: 'vitalik.gwei', wns: 'vitalik.wei' }
 
 // Rich lookup: resolve or reverse, and learn which system answered
-await names.lookup('alice.gwei')
-// => { input: 'alice.gwei', name: 'alice.gwei', address: '0x...', system: 'gns' }
+await names.lookup('alice.wei')
+// => { input: 'alice.wei', name: 'alice.wei', address: '0x...', system: 'wns' }
 
-// Records work across both systems
+// Records work across all systems
 await names.getAvatar('vitalik.eth')
-await names.getText('alice.gwei', 'url')
+await names.getText('alice.wei', 'url')
 
 // Pure, offline system detection
 names.system('alice.gwei') // 'gns'
+names.system('alice.wei')  // 'wns'
 names.system('foo.eth')    // 'ens'
 ```
 
@@ -53,6 +56,7 @@ names.system('foo.eth')    // 'ens'
 
 | Input                       | System |
 | --------------------------- | ------ |
+| `*.wei`                     | WNS    |
 | `*.gwei`                    | GNS    |
 | bare label (no dot)         | GNS    |
 | any other dotted name `*.eth`, `*.box`, … | ENS |
@@ -60,7 +64,7 @@ names.system('foo.eth')    // 'ens'
 
 Reverse lookups try each system in order (ENS first by default) and return the first
 match. Configure the order with `reversePriority`, or use `reverseAll` to get the primary
-name from **both** systems at once.
+name from **all** systems at once.
 
 By default, reverse lookups are **forward-verified**: after reading an address's primary
 name, the library resolves that name back and confirms it points to the same address
@@ -82,7 +86,7 @@ const names = createEthereumNames({ client })
 const quick = createEthereumNames({ rpcUrl: 'https://my-rpc' })
 
 // Prefer GNS names on reverse lookups
-const gnsFirst = createEthereumNames({ reversePriority: ['gns', 'ens'] })
+const gnsFirst = createEthereumNames({ reversePriority: ['gns', 'ens', 'wns'] })
 ```
 
 | Option            | Type                  | Description                                                           |
@@ -91,12 +95,12 @@ const gnsFirst = createEthereumNames({ reversePriority: ['gns', 'ens'] })
 | `rpcUrl`          | `string`              | RPC endpoint used when no `client` is given.                         |
 | `chain`           | `Chain`               | Chain used when no `client` is given. Defaults to `mainnet`.         |
 | `gnsContract`     | `Address`             | Override the GNS contract address.                                   |
-| `reversePriority` | `('ens' \| 'gns')[]`  | Order reverse lookups try each system. Defaults to `['ens', 'gns']`. |
+| `wnsContract`     | `Address`             | Override the WNS contract address.                                   |
+| `reversePriority` | `('ens' \| 'gns' \| 'wns')[]` | Order reverse lookups try each system. Defaults to `['ens', 'gns', 'wns']`. |
 | `verify`          | `boolean`             | Forward-verify reverse lookups before trusting them. Defaults to `true`. |
 
 > **Note:** ENS resolution relies on viem's ENS actions, which require a chain with ENS
-> contracts configured (such as `mainnet`). GNS is live at the same address on Ethereum
-> mainnet and Sepolia.
+> contracts configured (such as `mainnet`). GNS and WNS are live on Ethereum mainnet.
 
 ## API
 
@@ -106,20 +110,21 @@ const gnsFirst = createEthereumNames({ reversePriority: ['gns', 'ens'] })
 | ----------------------- | ----------------------------- | ------------------------------------------------------- |
 | `resolve(nameOrAddress)`| `Promise<Address \| null>`    | Name → address. Addresses pass through, checksummed.    |
 | `reverse(address)`      | `Promise<string \| null>`     | Address → primary name across systems.                  |
-| `reverseAll(address)`   | `Promise<ReverseNames>`       | Address → `{ ens, gns }` primary names from both systems.|
+| `reverseAll(address)`   | `Promise<ReverseNames>`       | Address → `{ ens, gns, wns }` primary names from every system.|
 | `lookup(input)`         | `Promise<ResolvedName>`       | Resolve or reverse, with the answering `system`.        |
-| `getAvatar(name)`       | `Promise<string \| null>`     | Avatar record (ENS avatar, or GNS `avatar` text).       |
+| `getAvatar(name)`       | `Promise<string \| null>`     | Avatar record (ENS avatar, or GNS/WNS `avatar` text).   |
 | `getText(name, key)`    | `Promise<string \| null>`     | Arbitrary text record.                                  |
-| `system(name)`          | `'ens' \| 'gns' \| null`      | Offline system detection.                               |
+| `system(name)`          | `'ens' \| 'gns' \| 'wns' \| null` | Offline system detection.                           |
 | `client`                | `PublicClient`                | The underlying viem client.                             |
 
-Also exported: `detectSystem(name)`, `DEFAULT_GNS_CONTRACT`, and the types
-`EthereumNames`, `EthereumNamesConfig`, `NameSystem`, `ResolvedName`, `ReverseNames`.
+Also exported: `detectSystem(name)`, `DEFAULT_GNS_CONTRACT`, `DEFAULT_WNS_CONTRACT`, and the
+types `EthereumNames`, `EthereumNamesConfig`, `NameSystem`, `ResolvedName`, `ReverseNames`.
 
 ## Credits
 
 GNS resolution builds on [`@donnoh/gns-utils`](https://www.npmjs.com/package/@donnoh/gns-utils)
-by [lucadonnoh](https://github.com/lucadonnoh/gwei-names).
+by [lucadonnoh](https://github.com/lucadonnoh/gwei-names). WNS resolution builds on
+[`wns-utils`](https://www.npmjs.com/package/wns-utils) by [NaniDAO](https://github.com/NaniDAO/wns-utils).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@1001-digital/ethereum-names",
   "version": "0.1.0",
-  "description": "One clean API to resolve Ethereum names across ENS and the Gwei Name Service (GNS), powered by viem.",
+  "description": "One clean API to resolve Ethereum names across ENS, the Gwei Name Service (GNS), and the Wei Name Service (WNS), powered by viem.",
   "type": "module",
   "publishConfig": {
     "access": "public"
@@ -45,6 +45,9 @@
     "gns",
     "gwei",
     "gwei-name-service",
+    "wns",
+    "wei",
+    "wei-name-service",
     "name-service",
     "resolver",
     "viem",
@@ -61,7 +64,8 @@
   },
   "homepage": "https://github.com/1001-digital/ethereum-names#readme",
   "dependencies": {
-    "@donnoh/gns-utils": "^0.2.0"
+    "@donnoh/gns-utils": "^0.2.0",
+    "wns-utils": "^0.2.1"
   },
   "peerDependencies": {
     "viem": "^2.0.0"
@@ -78,6 +82,9 @@
   },
   "packageManager": "pnpm@10.30.0",
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "@biomejs/biome"]
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "@biomejs/biome"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@donnoh/gns-utils':
         specifier: ^0.2.0
         version: 0.2.0
+      wns-utils:
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -1235,6 +1238,9 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  wns-utils@0.2.1:
+    resolution: {integrity: sha512-gZY1oM4vpusuy5KrtixBmHzkduT+r2rJ3j2Ixh50aQlRxxs7m/yOZMG3fhFeu62IVF7312i9uQyKmju+zAMNxg==}
+
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
@@ -2298,5 +2304,7 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  wns-utils@0.2.1: {}
 
   ws@8.20.1: {}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
-import { normalizeName } from '@donnoh/gns-utils'
+import { normalizeName as gnsNormalizeName } from '@donnoh/gns-utils'
 import { http, type Address, createPublicClient, getAddress, isAddress, isAddressEqual } from 'viem'
 import { mainnet } from 'viem/chains'
+import { normalizeName as wnsNormalizeName } from 'wns-utils'
 import { ensAvatar, ensResolve, ensReverse, ensText } from './ens.js'
 import { DEFAULT_GNS_CONTRACT, gnsResolve, gnsReverse, gnsText } from './gns.js'
 import type {
@@ -11,9 +12,10 @@ import type {
   ReverseNames,
 } from './types.js'
 import { detectSystem, safeNormalizeEns } from './utils.js'
+import { DEFAULT_WNS_CONTRACT, wnsResolve, wnsReverse, wnsText } from './wns.js'
 
 /**
- * Create a unified ENS + GNS name client.
+ * Create a unified ENS + GNS + WNS name client.
  *
  * @example
  * ```ts
@@ -23,7 +25,8 @@ import { detectSystem, safeNormalizeEns } from './utils.js'
  *
  * await names.resolve('vitalik.eth')   // ENS  → 0x...
  * await names.resolve('alice.gwei')    // GNS  → 0x...
- * await names.reverse('0xd8dA...')     // → 'vitalik.eth' | 'alice.gwei' | null
+ * await names.resolve('alice.wei')     // WNS  → 0x...
+ * await names.reverse('0xd8dA...')     // → 'vitalik.eth' | 'alice.gwei' | 'alice.wei' | null
  * ```
  *
  * @example
@@ -45,12 +48,14 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
     })
 
   const gnsContract = config.gnsContract ?? DEFAULT_GNS_CONTRACT
-  const reversePriority: NameSystem[] = config.reversePriority ?? ['ens', 'gns']
+  const wnsContract = config.wnsContract ?? DEFAULT_WNS_CONTRACT
+  const reversePriority: NameSystem[] = config.reversePriority ?? ['ens', 'gns', 'wns']
   const verify = config.verify ?? true
 
   /** Canonical form of a name for a given system. */
   function canonical(name: string, system: NameSystem | null): string | null {
-    if (system === 'gns') return normalizeName(name)
+    if (system === 'gns') return gnsNormalizeName(name)
+    if (system === 'wns') return wnsNormalizeName(name)
     if (system === 'ens') return safeNormalizeEns(name)
     return null
   }
@@ -58,6 +63,7 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
   async function resolveName(name: string, system: NameSystem): Promise<Address | null> {
     try {
       if (system === 'ens') return await ensResolve(client, name)
+      if (system === 'wns') return await wnsResolve(client, wnsContract, name)
       return await gnsResolve(client, gnsContract, name)
     } catch {
       return null
@@ -67,6 +73,7 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
   async function rawReverse(system: NameSystem, address: Address): Promise<string | null> {
     try {
       if (system === 'ens') return await ensReverse(client, address)
+      if (system === 'wns') return await wnsReverse(client, wnsContract, address)
       return await gnsReverse(client, gnsContract, address)
     } catch {
       return null
@@ -108,13 +115,14 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
     },
 
     async reverseAll(address): Promise<ReverseNames> {
-      if (!isAddress(address)) return { ens: null, gns: null }
+      if (!isAddress(address)) return { ens: null, gns: null, wns: null }
       const checksummed = getAddress(address)
-      const [ens, gns] = await Promise.all([
+      const [ens, gns, wns] = await Promise.all([
         reverseFor('ens', checksummed),
         reverseFor('gns', checksummed),
+        reverseFor('wns', checksummed),
       ])
-      return { ens, gns }
+      return { ens, gns, wns }
     },
 
     async lookup(input): Promise<ResolvedName> {
@@ -138,6 +146,7 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
       try {
         if (system === 'ens') return await ensAvatar(client, name)
         if (system === 'gns') return await gnsText(client, gnsContract, name, 'avatar')
+        if (system === 'wns') return await wnsText(client, wnsContract, name, 'avatar')
       } catch {
         return null
       }
@@ -149,6 +158,7 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
       try {
         if (system === 'ens') return await ensText(client, name, key)
         if (system === 'gns') return await gnsText(client, gnsContract, name, key)
+        if (system === 'wns') return await wnsText(client, wnsContract, name, key)
       } catch {
         return null
       }

--- a/src/ethereum-names.test.ts
+++ b/src/ethereum-names.test.ts
@@ -9,6 +9,10 @@ test('detectSystem routes names to the right system', () => {
   assert.equal(detectSystem('foo.box'), 'ens')
   assert.equal(detectSystem('alice.gwei'), 'gns')
   assert.equal(detectSystem('ALICE.GWEI'), 'gns')
+  assert.equal(detectSystem('alice.wei'), 'wns')
+  assert.equal(detectSystem('ALICE.WEI'), 'wns')
+  // .gwei must not be mistaken for .wei
+  assert.equal(detectSystem('gm.gwei'), 'gns')
   // bare labels are treated as .gwei
   assert.equal(detectSystem('alice'), 'gns')
   assert.equal(detectSystem(''), null)
@@ -19,6 +23,7 @@ test('system() mirrors detectSystem without a network call', () => {
   const names = createEthereumNames()
   assert.equal(names.system('vitalik.eth'), 'ens')
   assert.equal(names.system('alice.gwei'), 'gns')
+  assert.equal(names.system('alice.wei'), 'wns')
 })
 
 test('resolve passes addresses through, checksummed', async () => {
@@ -34,7 +39,11 @@ test('reverse rejects non-addresses', async () => {
 
 test('reverseAll rejects non-addresses with an empty result', async () => {
   const names = createEthereumNames()
-  assert.deepEqual(await names.reverseAll('not-an-address'), { ens: null, gns: null })
+  assert.deepEqual(await names.reverseAll('not-an-address'), {
+    ens: null,
+    gns: null,
+    wns: null,
+  })
 })
 
 test('lookup of an address echoes the checksummed address', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { createEthereumNames } from './client.js'
 export { detectSystem } from './utils.js'
 export { DEFAULT_GNS_CONTRACT } from './gns.js'
+export { DEFAULT_WNS_CONTRACT } from './wns.js'
 export type {
   EthereumNames,
   EthereumNamesConfig,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { Address, Chain, PublicClient } from 'viem'
 
 /** The name systems this library understands. */
-export type NameSystem = 'ens' | 'gns'
+export type NameSystem = 'ens' | 'gns' | 'wns'
 
 /** Every primary name found for an address, keyed by system. */
 export interface ReverseNames {
@@ -9,13 +9,15 @@ export interface ReverseNames {
   ens: string | null
   /** Primary GNS (`.gwei`) name, or `null` if none is set (or it failed verification). */
   gns: string | null
+  /** Primary WNS (`.wei`) name, or `null` if none is set (or it failed verification). */
+  wns: string | null
 }
 
 /** Rich result describing a resolved name or address. */
 export interface ResolvedName {
   /** The original input, untouched. */
   input: string
-  /** The canonical name, when known (e.g. `vitalik.eth`, `alice.gwei`). */
+  /** The canonical name, when known (e.g. `vitalik.eth`, `alice.gwei`, `alice.wei`). */
   name: string | null
   /** The resolved address, when known (checksummed). */
   address: Address | null
@@ -36,7 +38,9 @@ export interface EthereumNamesConfig {
   chain?: Chain
   /** Override the GNS contract address. Defaults to the canonical deployment. */
   gnsContract?: Address
-  /** Order in which reverse lookups try each system. Defaults to `['ens', 'gns']`. */
+  /** Override the WNS contract address. Defaults to the canonical deployment. */
+  wnsContract?: Address
+  /** Order in which reverse lookups try each system. Defaults to `['ens', 'gns', 'wns']`. */
   reversePriority?: NameSystem[]
   /**
    * Forward-verify reverse lookups: after reading an address's primary name,
@@ -52,20 +56,23 @@ export interface EthereumNames {
   readonly client: PublicClient
   /**
    * Resolve a name to an address. Accepts ENS names (`vitalik.eth`), GNS names
-   * (`alice.gwei` or the bare label `alice`), or an address (returned checksummed).
-   * Returns `null` when nothing resolves.
+   * (`alice.gwei` or the bare label `alice`), WNS names (`alice.wei`), or an
+   * address (returned checksummed). Returns `null` when nothing resolves.
    */
   resolve(nameOrAddress: string): Promise<Address | null>
   /** Reverse resolve an address to its primary name, trying each system in priority order. */
   reverse(address: string): Promise<string | null>
   /**
-   * Reverse resolve an address across *both* systems, returning every primary
-   * name found. Use this when an address may have both an ENS and a GNS name.
+   * Reverse resolve an address across *all* systems, returning every primary
+   * name found. Use this when an address may have an ENS, GNS, and/or WNS name.
    */
   reverseAll(address: string): Promise<ReverseNames>
   /** Resolve or reverse-resolve `input`, returning a rich {@link ResolvedName}. */
   lookup(input: string): Promise<ResolvedName>
-  /** Read the `avatar` for a name (ENS avatar record, or the GNS `avatar` text record). */
+  /**
+   * Read the `avatar` for a name (ENS avatar record, or the GNS/WNS `avatar`
+   * text record).
+   */
   getAvatar(name: string): Promise<string | null>
   /** Read an arbitrary text record for a name. */
   getText(name: string, key: string): Promise<string | null>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import type { NameSystem } from './types.js'
  * Detect which name system an input belongs to, purely from its shape — no
  * network calls.
  *
+ * - `*.wei` → `wns`
  * - `*.gwei` and bare labels (no dot) → `gns`
  * - any other dotted name (`*.eth`, `*.box`, …) → `ens`
  * - empty input → `null`
@@ -12,6 +13,7 @@ import type { NameSystem } from './types.js'
 export function detectSystem(input: string): NameSystem | null {
   const value = input.trim().toLowerCase()
   if (!value) return null
+  if (value.endsWith('.wei')) return 'wns'
   if (value.endsWith('.gwei')) return 'gns'
   if (value.includes('.')) return 'ens'
   // A bare label is treated as a `.gwei` name, matching @donnoh/gns-utils.

--- a/src/wns.ts
+++ b/src/wns.ts
@@ -1,0 +1,71 @@
+import { type Address, getAddress, isAddressEqual, zeroAddress } from 'viem'
+import type { PublicClient } from 'viem'
+import { readContract } from 'viem/actions'
+import { WNS_CONTRACT, normalizeName, wnsAbi } from 'wns-utils'
+
+/** The canonical WNS contract. */
+export const DEFAULT_WNS_CONTRACT = WNS_CONTRACT as Address
+
+/**
+ * Compute the on-chain token id for a `.wei` name. WNS `computeId` is a `pure`
+ * hash, so it returns a non-zero id for any well-formed label regardless of
+ * whether the name is registered — "not found" is detected downstream via the
+ * zero address / empty record, not via the id.
+ */
+function tokenId(client: PublicClient, contract: Address, name: string): Promise<bigint> {
+  return readContract(client, {
+    address: contract,
+    abi: wnsAbi,
+    functionName: 'computeId',
+    args: [normalizeName(name)],
+  }) as Promise<bigint>
+}
+
+/** Resolve a `.wei` name to an address. */
+export async function wnsResolve(
+  client: PublicClient,
+  contract: Address,
+  name: string,
+): Promise<Address | null> {
+  const id = await tokenId(client, contract, name)
+  const addr = (await readContract(client, {
+    address: contract,
+    abi: wnsAbi,
+    functionName: 'resolve',
+    args: [id],
+  })) as Address
+  if (!addr || isAddressEqual(addr, zeroAddress)) return null
+  return getAddress(addr)
+}
+
+/** Reverse resolve an address to its primary `.wei` name. */
+export async function wnsReverse(
+  client: PublicClient,
+  contract: Address,
+  address: Address,
+): Promise<string | null> {
+  const name = (await readContract(client, {
+    address: contract,
+    abi: wnsAbi,
+    functionName: 'reverseResolve',
+    args: [address],
+  })) as string
+  return name || null
+}
+
+/** Read a text record for a `.wei` name. */
+export async function wnsText(
+  client: PublicClient,
+  contract: Address,
+  name: string,
+  key: string,
+): Promise<string | null> {
+  const id = await tokenId(client, contract, name)
+  const value = (await readContract(client, {
+    address: contract,
+    abi: wnsAbi,
+    functionName: 'text',
+    args: [id, key],
+  })) as string
+  return value || null
+}


### PR DESCRIPTION
Resolve, reverse-resolve, and read records for .wei names via wns-utils, mirroring the existing GNS integration on the shared viem client.

- New src/wns.ts: wnsResolve/wnsReverse/wnsText + DEFAULT_WNS_CONTRACT
- detectSystem routes *.wei -> 'wns'
- reverseAll returns { ens, gns, wns }; reversePriority defaults to ['ens', 'gns', 'wns']; new wnsContract config option
- NameSystem gains 'wns'; ReverseNames gains wns
- Docs, keywords, tests, and a changeset