### PR TITLE
Make the resolved name systems configurable

### DIFF
--- a/.changeset/soft-eels-smile.md
+++ b/.changeset/soft-eels-smile.md
@@ -1,0 +1,31 @@
+---
+'@1001-digital/ethereum-names': minor
+---
+
+Make the set of resolved name systems configurable. GNS and WNS were hardcoded into the
+resolving path, so adding a TLD meant forking the library. They are now just the default
+entries in a `registries` list — any contract with the same read interface (`computeId`,
+`resolve`, `reverseResolve`, `text`) can join:
+
+```ts
+import { createEthereumNames, DEFAULT_REGISTRIES } from '@1001-digital/ethereum-names'
+
+const names = createEthereumNames({
+  registries: [...DEFAULT_REGISTRIES, { id: 'foo', suffix: '.foo', contract: '0x…' }],
+})
+
+await names.resolve('alice.foo')     // → 0x…
+await names.reverseAll('0xd8dA…')    // → { ens, gns, wns, foo }
+```
+
+A registry's `id` names it everywhere: `system()`, `lookup()`, the `reverseAll()` keys, and
+the `bareLabel` / `reversePriority` options. Suffixes are matched longest-first, so `.gwei`
+is never shadowed by `.wei` regardless of order. Invalid registries (the reserved id `ens`,
+duplicate ids, a suffix without its leading dot) throw at construction.
+
+Also exported: `DEFAULT_REGISTRIES` and the `NameRegistry` type. `detectSystem` takes an
+optional third `registries` argument.
+
+Backwards compatible: `NameSystem` widens rather than changes, `ReverseNames` keeps `ens` /
+`gns` / `wns` always present, `gnsContract` / `wnsContract` still override the default
+addresses, and the defaults are unchanged.

--- a/README.md
+++ b/README.md
@@ -58,9 +58,12 @@ names.system('foo.eth')    // 'ens'
 | --------------------------- | ------ |
 | `*.wei`                     | WNS    |
 | `*.gwei`                    | GNS    |
+| any suffix from a custom registry | that registry (see [Custom registries](#custom-registries)) |
 | any other dotted name `*.eth`, `*.box`, … | ENS |
 | bare label (no dot)         | `bareLabel` option (default ENS) |
 | `0x…` address               | passed through (checksummed) |
+
+Suffixes are matched longest-first, so `.gwei` is never mistaken for `.wei`.
 
 A bare label like `alice` is ambiguous — GNS (`.gwei`) and WNS (`.wei`) both accept bare
 labels, and they can point to different owners. Rather than guess, it resolves against the
@@ -104,14 +107,62 @@ await gwei.resolve('alice') // → resolves alice.gwei
 | `client`          | `PublicClient`        | A viem client to read from. Its chain must have ENS contracts.       |
 | `rpcUrl`          | `string`              | RPC endpoint used when no `client` is given.                         |
 | `chain`           | `Chain`               | Chain used when no `client` is given. Defaults to `mainnet`.         |
+| `registries`      | `NameRegistry[]`      | The non-ENS registries to resolve against. Defaults to `DEFAULT_REGISTRIES` (GNS + WNS). |
 | `gnsContract`     | `Address`             | Override the GNS contract address.                                   |
 | `wnsContract`     | `Address`             | Override the WNS contract address.                                   |
-| `bareLabel`       | `'ens' \| 'gns' \| 'wns'` | System a bare label (no dot) resolves against. Defaults to `'ens'`. |
-| `reversePriority` | `('ens' \| 'gns' \| 'wns')[]` | Order reverse lookups try each system. Defaults to `['ens', 'gns', 'wns']`. |
+| `bareLabel`       | `NameSystem`          | System a bare label (no dot) resolves against. Defaults to `'ens'`.  |
+| `reversePriority` | `NameSystem[]`        | Order reverse lookups try each system. Defaults to `'ens'` then each registry — `['ens', 'gns', 'wns']`. |
 | `verify`          | `boolean`             | Forward-verify reverse lookups before trusting them. Defaults to `true`. |
 
 > **Note:** ENS resolution relies on viem's ENS actions, which require a chain with ENS
 > contracts configured (such as `mainnet`). GNS and WNS are live on Ethereum mainnet.
+
+## Custom registries
+
+GNS and WNS are just two instances of the same shape: an on-chain registry exposing
+`computeId(string)`, `resolve(uint256)`, `reverseResolve(address)`, and
+`text(uint256, string)`. Any registry with that read interface can join the resolving path
+— no fork required. Pass it as `registries`, spreading `DEFAULT_REGISTRIES` so you *add* to
+GNS and WNS instead of replacing them:
+
+```ts
+import { createEthereumNames, DEFAULT_REGISTRIES } from '@1001-digital/ethereum-names'
+
+const names = createEthereumNames({
+  registries: [
+    ...DEFAULT_REGISTRIES,
+    { id: 'foo', suffix: '.foo', contract: '0x…' },
+  ],
+})
+
+await names.resolve('alice.foo')     // → '0x…' | null
+names.system('alice.foo')            // → 'foo'
+await names.reverseAll('0xd8dA…')    // → { ens, gns, wns, foo }
+await names.getText('alice.foo', 'url')
+```
+
+The `id` you choose is the name of the system everywhere else: it is what `system()` and
+`lookup()` return, what `reverseAll()` keys the result by, and what you may pass to
+`bareLabel` and `reversePriority`.
+
+```ts
+// Try your registry before ENS on reverse lookups, and treat bare labels as `.foo` names
+createEthereumNames({
+  registries: [...DEFAULT_REGISTRIES, { id: 'foo', suffix: '.foo', contract: '0x…' }],
+  reversePriority: ['foo', 'ens', 'gns', 'wns'],
+  bareLabel: 'foo',
+})
+```
+
+A few rules, enforced at construction (they throw rather than fail silently at resolve
+time): `id` cannot be `'ens'` (reserved) and must be unique; `suffix` must include its
+leading dot. Because `registries` replaces the defaults, omitting the spread is how you opt
+*out* of GNS or WNS. `ens`, `gns`, and `wns` remain present as `null` keys on `reverseAll`
+either way, so existing consumers of that shape keep working.
+
+ENS itself is not pluggable this way — it resolves through viem's universal resolver, which
+already covers every TLD in the ENS root (`.eth`, `.box`, offchain CCIP-read names, …).
+Those work with no configuration at all.
 
 ## API
 
@@ -121,15 +172,16 @@ await gwei.resolve('alice') // → resolves alice.gwei
 | ----------------------- | ----------------------------- | ------------------------------------------------------- |
 | `resolve(nameOrAddress)`| `Promise<Address \| null>`    | Name → address. Addresses pass through, checksummed.    |
 | `reverse(address)`      | `Promise<string \| null>`     | Address → primary name across systems.                  |
-| `reverseAll(address)`   | `Promise<ReverseNames>`       | Address → `{ ens, gns, wns }` primary names from every system.|
+| `reverseAll(address)`   | `Promise<ReverseNames>`       | Address → `{ ens, gns, wns, …registries }` primary names from every system.|
 | `lookup(input)`         | `Promise<ResolvedName>`       | Resolve or reverse, with the answering `system`.        |
-| `getAvatar(name)`       | `Promise<string \| null>`     | Avatar record (ENS avatar, or GNS/WNS `avatar` text).   |
+| `getAvatar(name)`       | `Promise<string \| null>`     | Avatar record (ENS avatar, or the registry's `avatar` text). |
 | `getText(name, key)`    | `Promise<string \| null>`     | Arbitrary text record.                                  |
-| `system(name)`          | `'ens' \| 'gns' \| 'wns' \| null` | Offline system detection.                           |
+| `system(name)`          | `NameSystem \| null`          | Offline system detection.                               |
 | `client`                | `PublicClient`                | The underlying viem client.                             |
 
-Also exported: `detectSystem(name)`, `DEFAULT_GNS_CONTRACT`, `DEFAULT_WNS_CONTRACT`, and the
-types `EthereumNames`, `EthereumNamesConfig`, `NameSystem`, `ResolvedName`, `ReverseNames`.
+Also exported: `detectSystem(name, bareLabel?, registries?)`, `DEFAULT_REGISTRIES`,
+`DEFAULT_GNS_CONTRACT`, `DEFAULT_WNS_CONTRACT`, and the types `EthereumNames`,
+`EthereumNamesConfig`, `NameRegistry`, `NameSystem`, `ResolvedName`, `ReverseNames`.
 
 ## Credits
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,17 +1,11 @@
 import { http, type Address, createPublicClient, getAddress, isAddress, isAddressEqual } from 'viem'
 import { mainnet } from 'viem/chains'
 import { ensAvatar, ensResolve, ensReverse, ensText } from './ens.js'
-import {
-  DEFAULT_GNS_CONTRACT,
-  DEFAULT_WNS_CONTRACT,
-  normalizeName,
-  nsResolve,
-  nsReverse,
-  nsText,
-} from './name-service.js'
+import { DEFAULT_REGISTRIES, normalizeName, nsResolve, nsReverse, nsText } from './name-service.js'
 import type {
   EthereumNames,
   EthereumNamesConfig,
+  NameRegistry,
   NameSystem,
   ResolvedName,
   ReverseNames,
@@ -19,7 +13,37 @@ import type {
 import { detectSystem, safeNormalizeEns } from './utils.js'
 
 /**
- * Create a unified ENS + GNS + WNS name client.
+ * Apply the `gnsContract`/`wnsContract` shorthands, normalize ids and suffixes,
+ * and reject registries that can never resolve.
+ */
+function buildRegistries(config: EthereumNamesConfig): NameRegistry[] {
+  const overrides: Record<string, Address | undefined> = {
+    gns: config.gnsContract,
+    wns: config.wnsContract,
+  }
+
+  const registries = (config.registries ?? DEFAULT_REGISTRIES).map((registry) => ({
+    id: registry.id.toLowerCase(),
+    suffix: registry.suffix.toLowerCase(),
+    contract: overrides[registry.id.toLowerCase()] ?? registry.contract,
+  }))
+
+  const seen = new Set<string>()
+  for (const { id, suffix } of registries) {
+    if (id === 'ens') throw new Error('Registry id "ens" is reserved for ENS itself.')
+    if (seen.has(id)) throw new Error(`Duplicate registry id "${id}".`)
+    if (!suffix.startsWith('.')) {
+      throw new Error(`Registry "${id}" suffix must start with a dot (got "${suffix}").`)
+    }
+    seen.add(id)
+  }
+
+  return registries
+}
+
+/**
+ * Create a unified name client across ENS and any number of GNS/WNS-style
+ * registries (GNS and WNS by default).
  *
  * @example
  * ```ts
@@ -42,6 +66,20 @@ import { detectSystem, safeNormalizeEns } from './utils.js'
  * const client = createPublicClient({ chain: mainnet, transport: http() })
  * const names = createEthereumNames({ client })
  * ```
+ *
+ * @example
+ * ```ts
+ * // Teach it a TLD it doesn't ship with (any registry with the same read
+ * // interface: computeId / resolve / reverseResolve / text)
+ * import { createEthereumNames, DEFAULT_REGISTRIES } from '@1001-digital/ethereum-names'
+ *
+ * const names = createEthereumNames({
+ *   registries: [...DEFAULT_REGISTRIES, { id: 'foo', suffix: '.foo', contract: '0x…' }],
+ * })
+ *
+ * await names.resolve('alice.foo')     // → 0x...
+ * await names.reverseAll('0xd8dA...')  // → { ens, gns, wns, foo }
+ * ```
  */
 export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumNames {
   const client =
@@ -51,28 +89,34 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
       transport: http(config.rpcUrl),
     })
 
-  const reversePriority: NameSystem[] = config.reversePriority ?? ['ens', 'gns', 'wns']
+  const registryList = buildRegistries(config)
+  const registries: Record<string, NameRegistry> = Object.fromEntries(
+    registryList.map((registry) => [registry.id, registry]),
+  )
+  /** Every system this client knows: ENS, then each registry in configured order. */
+  const systems: NameSystem[] = ['ens', ...registryList.map((registry) => registry.id)]
+
+  const reversePriority: NameSystem[] = config.reversePriority ?? systems
   const verify = config.verify ?? true
   const bareLabel: NameSystem = config.bareLabel ?? 'ens'
 
-  /** GNS and WNS share a registry interface — only the contract and suffix differ. */
-  const registries = {
-    gns: { contract: config.gnsContract ?? DEFAULT_GNS_CONTRACT, suffix: '.gwei' },
-    wns: { contract: config.wnsContract ?? DEFAULT_WNS_CONTRACT, suffix: '.wei' },
-  } as const
+  function systemOf(name: string): NameSystem | null {
+    return detectSystem(name, bareLabel, registryList)
+  }
 
   /** Canonical form of a name for a given system. */
   function canonical(name: string, system: NameSystem | null): string | null {
     if (system === 'ens') return safeNormalizeEns(name)
-    if (system === 'gns' || system === 'wns') return normalizeName(name, registries[system].suffix)
-    return null
+    const registry = system ? registries[system] : undefined
+    return registry ? normalizeName(name, registry.suffix) : null
   }
 
   async function resolveName(name: string, system: NameSystem): Promise<Address | null> {
     try {
       if (system === 'ens') return await ensResolve(client, name)
-      const { contract, suffix } = registries[system]
-      return await nsResolve(client, contract, name, suffix)
+      const registry = registries[system]
+      if (!registry) return null
+      return await nsResolve(client, registry.contract, name, registry.suffix)
     } catch {
       return null
     }
@@ -81,7 +125,9 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
   async function rawReverse(system: NameSystem, address: Address): Promise<string | null> {
     try {
       if (system === 'ens') return await ensReverse(client, address)
-      return await nsReverse(client, registries[system].contract, address)
+      const registry = registries[system]
+      if (!registry) return null
+      return await nsReverse(client, registry.contract, address)
     } catch {
       return null
     }
@@ -96,17 +142,28 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
     return forward && isAddressEqual(forward, address) ? name : null
   }
 
+  /**
+   * `ens`, `gns`, and `wns` are always present on {@link ReverseNames}, even when
+   * a custom `registries` list drops one — so seed them alongside the configured
+   * systems rather than only the latter.
+   */
+  function emptyReverseNames(): ReverseNames {
+    const empty: ReverseNames = { ens: null, gns: null, wns: null }
+    for (const system of systems) empty[system] = null
+    return empty
+  }
+
   return {
     client,
 
     system(name) {
-      return detectSystem(name, bareLabel)
+      return systemOf(name)
     },
 
     async resolve(nameOrAddress) {
       if (!nameOrAddress) return null
       if (isAddress(nameOrAddress)) return getAddress(nameOrAddress)
-      const system = detectSystem(nameOrAddress, bareLabel)
+      const system = systemOf(nameOrAddress)
       if (!system) return null
       return resolveName(nameOrAddress, system)
     },
@@ -122,14 +179,14 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
     },
 
     async reverseAll(address): Promise<ReverseNames> {
-      if (!isAddress(address)) return { ens: null, gns: null, wns: null }
+      const names = emptyReverseNames()
+      if (!isAddress(address)) return names
       const checksummed = getAddress(address)
-      const [ens, gns, wns] = await Promise.all([
-        reverseFor('ens', checksummed),
-        reverseFor('gns', checksummed),
-        reverseFor('wns', checksummed),
-      ])
-      return { ens, gns, wns }
+      const found = await Promise.all(systems.map((system) => reverseFor(system, checksummed)))
+      systems.forEach((system, index) => {
+        names[system] = found[index] ?? null
+      })
+      return names
     },
 
     async lookup(input): Promise<ResolvedName> {
@@ -142,20 +199,19 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
         return { input, name: null, address, system: null }
       }
 
-      const system = detectSystem(input, bareLabel)
+      const system = systemOf(input)
       if (!system) return { input, name: null, address: null, system: null }
       const address = await resolveName(input, system)
       return { input, name: canonical(input, system), address, system }
     },
 
     async getAvatar(name) {
-      const system = detectSystem(name, bareLabel)
+      const system = systemOf(name)
       try {
         if (system === 'ens') return await ensAvatar(client, name)
-        if (system === 'gns' || system === 'wns') {
-          const { contract, suffix } = registries[system]
-          return await nsText(client, contract, name, 'avatar', suffix)
-        }
+        const registry = system ? registries[system] : undefined
+        if (registry)
+          return await nsText(client, registry.contract, name, 'avatar', registry.suffix)
       } catch {
         return null
       }
@@ -163,13 +219,11 @@ export function createEthereumNames(config: EthereumNamesConfig = {}): EthereumN
     },
 
     async getText(name, key) {
-      const system = detectSystem(name, bareLabel)
+      const system = systemOf(name)
       try {
         if (system === 'ens') return await ensText(client, name, key)
-        if (system === 'gns' || system === 'wns') {
-          const { contract, suffix } = registries[system]
-          return await nsText(client, contract, name, key, suffix)
-        }
+        const registry = system ? registries[system] : undefined
+        if (registry) return await nsText(client, registry.contract, name, key, registry.suffix)
       } catch {
         return null
       }

--- a/src/ethereum-names.test.ts
+++ b/src/ethereum-names.test.ts
@@ -1,8 +1,16 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { createEthereumNames, detectSystem } from './index.js'
+import { DEFAULT_REGISTRIES, createEthereumNames, detectSystem } from './index.js'
+import type { NameRegistry } from './index.js'
 
 const VITALIK = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+
+/** A stand-in registry with the GNS/WNS read interface. Never called over the network here. */
+const FOO: NameRegistry = {
+  id: 'foo',
+  suffix: '.foo',
+  contract: '0x00000000000000000000000000000000000000F0',
+}
 
 test('detectSystem routes names to the right system', () => {
   assert.equal(detectSystem('vitalik.eth'), 'ens')
@@ -71,4 +79,95 @@ test('lookup of an unknown shape returns an empty result', async () => {
   const names = createEthereumNames()
   const result = await names.lookup('')
   assert.deepEqual(result, { input: '', name: null, address: null, system: null })
+})
+
+test('detectSystem routes custom registry suffixes', () => {
+  const registries = [...DEFAULT_REGISTRIES, FOO]
+  assert.equal(detectSystem('alice.foo', 'ens', registries), 'foo')
+  assert.equal(detectSystem('ALICE.FOO', 'ens', registries), 'foo')
+  // built-ins still route, and unknown TLDs still fall through to ENS
+  assert.equal(detectSystem('alice.gwei', 'ens', registries), 'gns')
+  assert.equal(detectSystem('alice.box', 'ens', registries), 'ens')
+  // bare labels can route to a custom registry
+  assert.equal(detectSystem('alice', 'foo', registries), 'foo')
+})
+
+test('detectSystem matches the longest suffix, whatever the registry order', () => {
+  // `.wei` first would shadow `.gwei` on a naive first-match
+  const registries = [
+    { id: 'wns', suffix: '.wei', contract: FOO.contract },
+    { id: 'gns', suffix: '.gwei', contract: FOO.contract },
+  ]
+  assert.equal(detectSystem('alice.gwei', 'ens', registries), 'gns')
+  assert.equal(detectSystem('alice.wei', 'ens', registries), 'wns')
+})
+
+test('registries config adds a TLD to the resolving path', () => {
+  const names = createEthereumNames({ registries: [...DEFAULT_REGISTRIES, FOO] })
+  assert.equal(names.system('alice.foo'), 'foo')
+  assert.equal(names.system('alice.gwei'), 'gns')
+  assert.equal(names.system('alice.wei'), 'wns')
+  assert.equal(names.system('vitalik.eth'), 'ens')
+})
+
+test('registries config replaces the defaults rather than extending them', () => {
+  const names = createEthereumNames({ registries: [FOO] })
+  assert.equal(names.system('alice.foo'), 'foo')
+  // without GNS configured, `.gwei` is just another dotted name → ENS
+  assert.equal(names.system('alice.gwei'), 'ens')
+})
+
+test('reverseAll keys every configured system, keeping ens/gns/wns present', async () => {
+  const names = createEthereumNames({ registries: [...DEFAULT_REGISTRIES, FOO] })
+  assert.deepEqual(await names.reverseAll('not-an-address'), {
+    ens: null,
+    gns: null,
+    wns: null,
+    foo: null,
+  })
+
+  // even when a registry is dropped, ens/gns/wns stay on the result type
+  const swapped = createEthereumNames({ registries: [FOO] })
+  assert.deepEqual(await swapped.reverseAll('not-an-address'), {
+    ens: null,
+    gns: null,
+    wns: null,
+    foo: null,
+  })
+})
+
+test('bareLabel can point at a custom registry', () => {
+  const names = createEthereumNames({
+    registries: [...DEFAULT_REGISTRIES, FOO],
+    bareLabel: 'foo',
+  })
+  assert.equal(names.system('alice'), 'foo')
+  // a suffixed name still ignores the bareLabel override
+  assert.equal(names.system('alice.wei'), 'wns')
+})
+
+test('gnsContract/wnsContract still override the default registry addresses', () => {
+  const gnsContract = '0x00000000000000000000000000000000000000A1' as const
+  // No network call to assert against, so assert the wiring does not throw and
+  // detection is unchanged — the address override is applied by id.
+  const names = createEthereumNames({ gnsContract })
+  assert.equal(names.system('alice.gwei'), 'gns')
+})
+
+test('invalid registries are rejected at construction', () => {
+  assert.throws(
+    () => createEthereumNames({ registries: [{ ...FOO, id: 'ens' }] }),
+    /reserved/i,
+    'the id "ens" is reserved',
+  )
+  assert.throws(
+    () => createEthereumNames({ registries: [FOO, { ...FOO, suffix: '.bar' }] }),
+    /duplicate/i,
+    'ids must be unique',
+  )
+  assert.throws(
+    () => createEthereumNames({ registries: [{ ...FOO, suffix: 'foo' }] }),
+    /dot/i,
+    'suffixes must start with a dot',
+  )
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
 export { createEthereumNames } from './client.js'
 export { detectSystem } from './utils.js'
-export { DEFAULT_GNS_CONTRACT, DEFAULT_WNS_CONTRACT } from './name-service.js'
+export {
+  DEFAULT_GNS_CONTRACT,
+  DEFAULT_REGISTRIES,
+  DEFAULT_WNS_CONTRACT,
+} from './name-service.js'
 export type {
   EthereumNames,
   EthereumNamesConfig,
+  NameRegistry,
   NameSystem,
   ResolvedName,
   ReverseNames,

--- a/src/name-service.ts
+++ b/src/name-service.ts
@@ -1,6 +1,7 @@
 import { type Address, getAddress, isAddressEqual, zeroAddress } from 'viem'
 import type { PublicClient } from 'viem'
 import { readContract } from 'viem/actions'
+import type { NameRegistry } from './types.js'
 
 /**
  * GNS and WNS are ERC-721 name registries with identical read interfaces,
@@ -8,6 +9,10 @@ import { readContract } from 'viem/actions'
  * the shared viem client rather than pulling in a per-service utility library:
  * the addresses are frozen, the token id is derived on-chain by the pure
  * `computeId`, and normalization is a trivial lowercase/trim/suffix.
+ *
+ * Nothing here is GNS- or WNS-specific beyond the two default addresses below —
+ * any registry with the same read surface can be plugged in via the `registries`
+ * config option.
  */
 
 /** The Gwei Name Service registry (`.gwei`). Same address on mainnet and Sepolia. */
@@ -15,7 +20,22 @@ export const DEFAULT_GNS_CONTRACT = '0x9D51D507BC7264d4fE8Ad1cf7Fe191933A0a81d6'
 /** The Wei Name Service registry (`.wei`). */
 export const DEFAULT_WNS_CONTRACT = '0x0000000000696760E15f265e828DB644A0c242EB' as Address
 
-/** The read surface shared by the GNS and WNS registries. */
+/**
+ * The registries resolved against out of the box. Spread this to add your own
+ * without dropping GNS and WNS:
+ *
+ * ```ts
+ * createEthereumNames({
+ *   registries: [...DEFAULT_REGISTRIES, { id: 'foo', suffix: '.foo', contract: '0x…' }],
+ * })
+ * ```
+ */
+export const DEFAULT_REGISTRIES: readonly NameRegistry[] = [
+  { id: 'gns', suffix: '.gwei', contract: DEFAULT_GNS_CONTRACT },
+  { id: 'wns', suffix: '.wei', contract: DEFAULT_WNS_CONTRACT },
+] as const
+
+/** The read surface every registry must expose. */
 const nameServiceAbi = [
   {
     type: 'function',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,32 @@
 import type { Address, Chain, PublicClient } from 'viem'
 
-/** The name systems this library understands. */
-export type NameSystem = 'ens' | 'gns' | 'wns'
+/**
+ * The name systems this library understands: `'ens'`, plus the id of every
+ * configured registry — `'gns'` and `'wns'` out of the box, or whatever ids you
+ * pass as `registries`. The `(string & {})` arm keeps autocomplete for the
+ * built-ins while still admitting custom ids.
+ */
+export type NameSystem = 'ens' | 'gns' | 'wns' | (string & {})
 
-/** Every primary name found for an address, keyed by system. */
+/**
+ * A name registry speaking the GNS/WNS read interface — `computeId(string)`,
+ * `resolve(uint256)`, `reverseResolve(address)`, `text(uint256, string)`.
+ * Pass these as `registries` to teach the client a TLD it doesn't know.
+ */
+export interface NameRegistry {
+  /** Names this system in `system()`, `bareLabel`, `reversePriority`, and `reverseAll`. Cannot be `'ens'`. */
+  id: string
+  /** The name suffix, leading dot included (e.g. `.gwei`). Matched longest-first, so `.gwei` beats `.wei`. */
+  suffix: string
+  /** The registry contract address. */
+  contract: Address
+}
+
+/**
+ * Every primary name found for an address, keyed by system. `ens`, `gns`, and
+ * `wns` are always present (`null` when unset); each custom registry adds a key
+ * under its own id.
+ */
 export interface ReverseNames {
   /** Primary ENS name, or `null` if none is set (or it failed verification). */
   ens: string | null
@@ -11,6 +34,8 @@ export interface ReverseNames {
   gns: string | null
   /** Primary WNS (`.wei`) name, or `null` if none is set (or it failed verification). */
   wns: string | null
+  /** Primary name from a custom registry, keyed by its id. */
+  [system: string]: string | null
 }
 
 /** Rich result describing a resolved name or address. */
@@ -36,19 +61,32 @@ export interface EthereumNamesConfig {
   rpcUrl?: string
   /** Chain used when no `client` is supplied. Defaults to `mainnet`. */
   chain?: Chain
-  /** Override the GNS contract address. Defaults to the canonical deployment. */
+  /**
+   * The non-ENS registries to resolve against. Defaults to `DEFAULT_REGISTRIES`
+   * (GNS and WNS). This *replaces* the defaults, so spread them to add a
+   * registry rather than swap them out:
+   *
+   * ```ts
+   * registries: [...DEFAULT_REGISTRIES, { id: 'foo', suffix: '.foo', contract: '0x…' }]
+   * ```
+   */
+  registries?: NameRegistry[]
+  /** Override the GNS contract address. Applies to the registry with id `gns`. */
   gnsContract?: Address
-  /** Override the WNS contract address. Defaults to the canonical deployment. */
+  /** Override the WNS contract address. Applies to the registry with id `wns`. */
   wnsContract?: Address
   /**
    * Which system a bare label (no dot, e.g. `alice`) is resolved against.
    * Bare labels are ambiguous — GNS (`.gwei`) and WNS (`.wei`) both accept
    * them — so this picks one deterministically instead of guessing an owner.
    * Defaults to `'ens'`; note ENS has no bare-label namespace, so bare labels
-   * resolve to `null` unless you set this to `'gns'` or `'wns'`.
+   * resolve to `null` unless you set this to another system.
    */
   bareLabel?: NameSystem
-  /** Order in which reverse lookups try each system. Defaults to `['ens', 'gns', 'wns']`. */
+  /**
+   * Order in which reverse lookups try each system. Defaults to `'ens'` followed
+   * by each configured registry, in order — `['ens', 'gns', 'wns']` by default.
+   */
   reversePriority?: NameSystem[]
   /**
    * Forward-verify reverse lookups: after reading an address's primary name,
@@ -64,22 +102,23 @@ export interface EthereumNames {
   readonly client: PublicClient
   /**
    * Resolve a name to an address. Accepts ENS names (`vitalik.eth`), GNS names
-   * (`alice.gwei` or the bare label `alice`), WNS names (`alice.wei`), or an
-   * address (returned checksummed). Returns `null` when nothing resolves.
+   * (`alice.gwei` or the bare label `alice`), WNS names (`alice.wei`), names from
+   * any custom registry, or an address (returned checksummed). Returns `null`
+   * when nothing resolves.
    */
   resolve(nameOrAddress: string): Promise<Address | null>
   /** Reverse resolve an address to its primary name, trying each system in priority order. */
   reverse(address: string): Promise<string | null>
   /**
    * Reverse resolve an address across *all* systems, returning every primary
-   * name found. Use this when an address may have an ENS, GNS, and/or WNS name.
+   * name found. Use this when an address may have a name in more than one system.
    */
   reverseAll(address: string): Promise<ReverseNames>
   /** Resolve or reverse-resolve `input`, returning a rich {@link ResolvedName}. */
   lookup(input: string): Promise<ResolvedName>
   /**
-   * Read the `avatar` for a name (ENS avatar record, or the GNS/WNS `avatar`
-   * text record).
+   * Read the `avatar` for a name (the ENS avatar record, or the registry's
+   * `avatar` text record).
    */
   getAvatar(name: string): Promise<string | null>
   /** Read an arbitrary text record for a name. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,22 +1,35 @@
 import { normalize } from 'viem/ens'
-import type { NameSystem } from './types.js'
+import { DEFAULT_REGISTRIES } from './name-service.js'
+import type { NameRegistry, NameSystem } from './types.js'
+
+/** Just the parts of a {@link NameRegistry} that matter for shape detection. */
+type SuffixRule = Pick<NameRegistry, 'id' | 'suffix'>
 
 /**
  * Detect which name system an input belongs to, purely from its shape — no
  * network calls.
  *
- * - `*.wei` → `wns`
- * - `*.gwei` → `gns`
+ * - a name ending in a registry's suffix → that registry's id (`.gwei` → `gns`,
+ *   `.wei` → `wns`, and whatever else you pass as `registries`)
  * - any other dotted name (`*.eth`, `*.box`, …) → `ens`
  * - a bare label (no dot) → `bareLabel` (default `'ens'`), since it is
- *   ambiguous between the GNS/WNS bare-label namespaces
+ *   ambiguous across the registries' bare-label namespaces
  * - empty input → `null`
+ *
+ * Suffixes are matched longest-first, so `.gwei` is never mistaken for `.wei`
+ * regardless of the order `registries` is given in.
  */
-export function detectSystem(input: string, bareLabel: NameSystem = 'ens'): NameSystem | null {
+export function detectSystem(
+  input: string,
+  bareLabel: NameSystem = 'ens',
+  registries: readonly SuffixRule[] = DEFAULT_REGISTRIES,
+): NameSystem | null {
   const value = input.trim().toLowerCase()
   if (!value) return null
-  if (value.endsWith('.wei')) return 'wns'
-  if (value.endsWith('.gwei')) return 'gns'
+  const match = [...registries]
+    .sort((a, b) => b.suffix.length - a.suffix.length)
+    .find((registry) => value.endsWith(registry.suffix.toLowerCase()))
+  if (match) return match.id
   if (value.includes('.')) return 'ens'
   // A bare label (no dot) is ambiguous across systems; route it per config.
   return bareLabel


### PR DESCRIPTION
GNS and WNS were hardcoded into the resolving path — their suffixes were string literals in detectSystem and the registry map, and NameSystem was a closed union — so a consumer could not add a TLD without forking.

Nothing in the resolution logic was ever GNS- or WNS-specific: both are registries with the same read interface, already generic over (contract, suffix). Lift them into a `registries` list, keyed by an `id` that names the system everywhere (system(), lookup(), reverseAll() keys, bareLabel, reversePriority), and match suffixes longest-first so .gwei can never be shadowed by .wei regardless of order.

Backwards compatible: NameSystem widens rather than changes, ReverseNames keeps ens/gns/wns always present, gnsContract/wnsContract still override the default addresses by id, and the defaults are unchanged.