### PR TITLE
Remove deprecated reversePriority option

### DIFF
--- a/.changeset/remove-reverse-priority.md
+++ b/.changeset/remove-reverse-priority.md
@@ -1,0 +1,5 @@
+---
+"@1001-digital/ethereum-names": minor
+---
+
+**Breaking:** remove the deprecated `reversePriority` option, superseded by `priority` in `0.4.0`. Migration: rename `reversePriority` to `priority` — same shape, and it also breaks forward collision ties.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@ await gwei.resolve('alice') // → resolves alice.gwei
 | `wnsContract` | `Address` | Override the WNS contract address. |
 | `bareLabel` | system id | System a bare label (no dot) resolves against. Defaults to `'ens'`. |
 | `priority` | system id`[]` | Order systems are tried in — reverse lookups, and `collisions: 'priority'`. Defaults to `['ens', …registries]`. |
-| `reversePriority` | system id`[]` | **Deprecated** — use `priority`. Still honored. |
 | `collisions` | `'safe' \| 'priority' \| fn` | What to do when a name resolves in several systems. Defaults to `'safe'`. |
 | `verify` | `boolean` | Forward-verify reverse lookups before trusting them. Defaults to `true`. |
 

--- a/src/ethereum-names.test.ts
+++ b/src/ethereum-names.test.ts
@@ -76,13 +76,6 @@ test('lookup of an address echoes the checksummed address', async () => {
   })
 })
 
-test('the deprecated reversePriority option still works', async () => {
-  const names = createEthereumNames({ reversePriority: [] })
-  const result = await names.lookup(VITALIK.toLowerCase())
-  assert.equal(result.address, VITALIK)
-  assert.deepEqual(result.matches, [])
-})
-
 test('lookup of an unknown shape returns an empty result', async () => {
   const names = createEthereumNames()
   const result = await names.lookup('')

--- a/src/systems.ts
+++ b/src/systems.ts
@@ -86,7 +86,6 @@ export interface ResolvableConfig {
   wnsContract?: Address
   bareLabel?: string
   priority?: readonly string[]
-  reversePriority?: readonly string[]
   collisions?: CollisionStrategy<string>
   verify?: boolean
 }
@@ -104,9 +103,9 @@ export interface ResolvedConfig {
 
 /**
  * Resolve the config into the systems a client knows, applying every default
- * and back-compat shim (`gnsContract`/`wnsContract` overrides, the deprecated
- * `reversePriority` alias) and rejecting anything that can never resolve — at
- * construction, loudly, rather than as a silent `null` later.
+ * and back-compat shim (the `gnsContract`/`wnsContract` overrides) and
+ * rejecting anything that can never resolve — at construction, loudly, rather
+ * than as a silent `null` later.
  */
 export function resolveConfig(config: ResolvableConfig): ResolvedConfig {
   const overrides: Record<string, Address | undefined> = {
@@ -150,7 +149,7 @@ export function resolveConfig(config: ResolvableConfig): ResolvedConfig {
   const descriptors = [...byId.values()]
   const ids = descriptors.map((system) => system.id)
 
-  const priority = [...(config.priority ?? config.reversePriority ?? ids)]
+  const priority = [...(config.priority ?? ids)]
   for (const id of priority) {
     if (!ids.includes(id)) unknownSystem(id, ids, ' in priority')
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,11 +234,6 @@ export interface EthereumNamesConfig<R extends readonly NameRegistry[] = readonl
    */
   priority?: readonly NoInfer<SystemId<R>>[]
   /**
-   * @deprecated Use `priority`, which covers reverse order *and* forward
-   * collision tie-breaking. Still honored when `priority` is not set.
-   */
-  reversePriority?: readonly NoInfer<SystemId<R>>[]
-  /**
    * What to do when one name resolves in several systems. Defaults to `'safe'`
    * — never silently pick. See {@link CollisionStrategy}.
    */


### PR DESCRIPTION
**Breaking:** drops the `reversePriority` config option, deprecated since 0.4.0 when `priority` superseded it.

Migration: rename `reversePriority` to `priority` — same shape, and it also breaks forward collision ties.

Ships as a minor bump (0.x convention) via the included changeset.