### PR TITLE
Memoize computeId per client to save a round-trip on repeat registry reads

### DIFF
--- a/.changeset/memoize-compute-id.md
+++ b/.changeset/memoize-compute-id.md
@@ -1,0 +1,5 @@
+---
+'@1001-digital/ethereum-names': patch
+---
+
+Memoize `computeId` per client: repeat registry reads of the same canonical name — a `lookup()` followed by a `getText()`, or resolving a name twice — now reuse the token id instead of paying the on-chain round-trip again. Only non-zero ids are cached (GNS answers `0` for unregistered names, which can change once the name is registered), and the memo is bounded and scoped to each client instance.

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,14 @@ import { http, type Address, createPublicClient, getAddress, isAddress, isAddres
 import type { PublicClient } from 'viem'
 import { mainnet } from 'viem/chains'
 import { ensAvatar, ensResolve, ensReverse, ensText } from './ens.js'
-import { DEFAULT_REGISTRIES, canonicalName, nsResolve, nsReverse, nsText } from './name-service.js'
+import {
+  DEFAULT_REGISTRIES,
+  canonicalName,
+  createIdCache,
+  nsResolve,
+  nsReverse,
+  nsText,
+} from './name-service.js'
 import { detectSystemsIn, preferredSystemIn, resolutionCandidatesIn } from './routing.js'
 import { type BuiltSystem, type ResolvableConfig, resolveConfig, unknownSystem } from './systems.js'
 import type {
@@ -117,6 +124,10 @@ export function createEthereumNames<
       transport: http(config.rpcUrl),
     })
 
+  // Token ids memoized for this client — repeat registry reads of a name skip
+  // the on-chain `computeId` round-trip. See `IdCache` in name-service.ts.
+  const ids = createIdCache()
+
   // The id inference is erased here and restored at the public boundary below.
   const { descriptors, byId, priority, bareLabel, verify, collisions } = resolveConfig({
     ...config,
@@ -142,7 +153,7 @@ export function createEthereumNames<
   /** Resolve an already-canonical name in exactly one system, with no error swallowing. */
   function forwardIn(system: BuiltSystem, canonical: string): Promise<Address | null> {
     if (system.kind === 'ens') return ensResolve(client, canonical)
-    return nsResolve(client, system.contract, canonical)
+    return nsResolve(client, system.contract, canonical, ids)
   }
 
   async function forwardMatch(system: BuiltSystem, name: string): Promise<Match> {
@@ -257,7 +268,7 @@ export function createEthereumNames<
     if (!canonical) return null
     try {
       if (system.kind === 'ens') return await viaEns(client, canonical, key)
-      return await nsText(client, system.contract, canonical, key)
+      return await nsText(client, system.contract, canonical, key, ids)
     } catch {
       return null
     }

--- a/src/name-service.ts
+++ b/src/name-service.ts
@@ -101,14 +101,50 @@ export function canonicalName(name: string, suffixes: readonly string[]): string
   return suffixes[0] ? value + suffixes[0] : value
 }
 
-/** Compute the on-chain token id for a canonical name. */
-function tokenId(client: PublicClient, contract: Address, fullName: string): Promise<bigint> {
-  return readContract(client, {
+/** How many computed ids a client remembers; past this the oldest entry is dropped. */
+const ID_CACHE_LIMIT = 1000
+
+/**
+ * A per-client memo of computed token ids, keyed by contract and canonical
+ * name. A non-zero id is stable forever — `computeId` is pure — so a repeat
+ * read of the same name (a `lookup()` followed by a `getText()`, say) can skip
+ * the round-trip. GNS answers id `0` for names it has never seen, and a later
+ * registration turns that into a real id: zero is registry state, not a hash,
+ * and is never cached. One memo per client — a module-global would bleed ids
+ * across clients pointed at different chains.
+ */
+export type IdCache = Map<string, bigint>
+
+/** A fresh, empty id memo. Create one per client — see {@link IdCache}. */
+export function createIdCache(): IdCache {
+  return new Map()
+}
+
+/** Compute the on-chain token id for a canonical name, memoized when a cache is supplied. */
+async function tokenId(
+  client: PublicClient,
+  contract: Address,
+  fullName: string,
+  cache?: IdCache,
+): Promise<bigint> {
+  const key = `${contract.toLowerCase()}:${fullName}`
+  const cached = cache?.get(key)
+  if (cached !== undefined) return cached
+  const id = (await readContract(client, {
     address: contract,
     abi: nameServiceAbi,
     functionName: 'computeId',
     args: [fullName],
-  }) as Promise<bigint>
+  })) as bigint
+  if (cache && id !== 0n) {
+    // Names are user-typed input, so the memo is bounded: full means the oldest goes.
+    if (cache.size >= ID_CACHE_LIMIT) {
+      const oldest = cache.keys().next().value
+      if (oldest) cache.delete(oldest)
+    }
+    cache.set(key, id)
+  }
+  return id
 }
 
 /**
@@ -119,8 +155,9 @@ export async function nsResolve(
   client: PublicClient,
   contract: Address,
   fullName: string,
+  cache?: IdCache,
 ): Promise<Address | null> {
-  const id = await tokenId(client, contract, fullName)
+  const id = await tokenId(client, contract, fullName, cache)
   if (id === 0n) return null
   const addr = (await readContract(client, {
     address: contract,
@@ -153,8 +190,9 @@ export async function nsText(
   contract: Address,
   fullName: string,
   key: string,
+  cache?: IdCache,
 ): Promise<string | null> {
-  const id = await tokenId(client, contract, fullName)
+  const id = await tokenId(client, contract, fullName, cache)
   if (id === 0n) return null
   const value = (await readContract(client, {
     address: contract,

--- a/src/resolution.test.ts
+++ b/src/resolution.test.ts
@@ -35,10 +35,56 @@ test('a name resolves through its registry', async () => {
   assert.equal(await names.resolve('alice.gwei'), ALICE)
   assert.equal(await names.resolve('ALICE.GWEI'), ALICE)
   assert.equal(await names.resolve('nobody.gwei'), null)
-  // one candidate means one system is asked — no cost added by collision handling
+  // one candidate means one system is asked — no cost added by collision
+  // handling — and the second read of `alice.gwei` reuses its memoized id,
+  // while the unknown name (id 0, mutable registry state) is asked again
   assert.deepEqual(
     log.calls.map((call) => call.function),
-    ['computeId', 'resolve', 'computeId', 'resolve', 'computeId'],
+    ['computeId', 'resolve', 'resolve', 'computeId'],
+  )
+})
+
+test('a repeat read of the same name skips the computeId round-trip', async () => {
+  const { client, log } = fakeClient({
+    [DEFAULT_GNS_CONTRACT]: {
+      names: { 'alice.gwei': ALICE },
+      text: { 'alice.gwei': { url: 'https://alice.example' } },
+      zeroForUnknown: true,
+    },
+  })
+  const names = createEthereumNames({ client })
+
+  assert.equal(await names.resolve('alice.gwei'), ALICE)
+  assert.equal(await names.resolve('alice.gwei'), ALICE)
+  assert.equal(await names.getText('alice.gwei', 'url'), 'https://alice.example')
+  // the id is computed once; the repeat resolve and the text read reuse it
+  assert.deepEqual(
+    log.calls.map((call) => call.function),
+    ['computeId', 'resolve', 'resolve', 'text'],
+  )
+})
+
+test('an unregistered name is never cached — its id 0 is registry state, not a hash', async () => {
+  const { client, log } = gnsOnly()
+  const names = createEthereumNames({ client })
+
+  assert.equal(await names.resolve('nobody.gwei'), null)
+  assert.equal(await names.resolve('nobody.gwei'), null)
+  // GNS answers id 0 until the name is registered, so both reads must ask
+  assert.deepEqual(
+    log.calls.map((call) => call.function),
+    ['computeId', 'computeId'],
+  )
+})
+
+test('the id memo is per client instance, not shared across clients', async () => {
+  const { client, log } = gnsOnly()
+  assert.equal(await createEthereumNames({ client }).resolve('alice.gwei'), ALICE)
+  assert.equal(await createEthereumNames({ client }).resolve('alice.gwei'), ALICE)
+  // two clients, two memos: each pays for its own computeId
+  assert.deepEqual(
+    log.calls.map((call) => call.function),
+    ['computeId', 'resolve', 'computeId', 'resolve'],
   )
 })
 


### PR DESCRIPTION
`computeId(fullName)` is a pure on-chain function of (contract, canonical name), yet every `nsResolve`/`nsText` paid it again — a `lookup()` followed by `getText()` on the same name recomputed the same token id on-chain. Registry reads now share a small per-client memo (`createIdCache()` in `name-service.ts`, wired in by `createEthereumNames`), so repeat reads of the same canonical name skip the `computeId` call and go straight to `resolve`/`text`.

**The one subtlety:** GNS's `computeId` returns `0` for names it has never seen — that is mutable registry state, not a hash, since a later registration turns it into a real id. Zero results are therefore never cached; only non-zero ids, which are stable forever. The memo is also bounded (~1000 entries, oldest evicted) since names are user-typed input, and strictly per client instance — never module-global — so ids can't bleed across clients pointed at different chains.

No public API changes; the cache parameter on `nsResolve`/`nsText` is optional and internal (not exported from the package entry).

**Tests** (against the existing `fakeClient` call log):
- a repeat `resolve()` and a `getText()` after `resolve()` reuse the id — exactly one `computeId` in the log
- an unregistered GNS-style name (`zeroForUnknown`) is not cached: resolving it twice calls `computeId` twice
- the memo is per client instance — two clients each pay their own `computeId`
- the exact call-sequence assertion in "a name resolves through its registry" is updated to the new, smaller sequence

`pnpm check`, `pnpm test` (43 passing), and `pnpm build` all pass.